### PR TITLE
change user-email-send to OSM-send-message-feature

### DIFF
--- a/include/email.php
+++ b/include/email.php
@@ -217,6 +217,10 @@ function pun_mail($to, $subject, $message, $reply_to_email = '', $reply_to_name 
 {
 	global $pun_config, $lang_common;
 
+	// Give up if there is no target address
+	if ($to == '')
+		return;
+
 	// Use \r\n for SMTP servers, the system's line ending for local mailers
 	$smtp = $pun_config['o_smtp_host'] != '';
 	$EOL = $smtp ? "\r\n" : FORUM_EOL;

--- a/include/email.php
+++ b/include/email.php
@@ -217,7 +217,7 @@ function pun_mail($to, $subject, $message, $reply_to_email = '', $reply_to_name 
 {
 	global $pun_config, $lang_common;
 
-	// Give up if there is no target address
+	// Give up if there is no target address (modification because of special OSM login)
 	if ($to == '')
 		return;
 

--- a/include/parser.php
+++ b/include/parser.php
@@ -696,7 +696,7 @@ function handle_url_tag($url, $link = '', $bbcode = false)
 		else
 			$link = stripslashes($link);
 
-		return '<a href="'.$full_url.'" rel="nofollow">'.$link.'</a>';
+		return '<a href="'.$full_url.'" rel="nofollow" target="_blank">'.$link.'</a>';
 	}
 }
 

--- a/profile.php
+++ b/profile.php
@@ -1093,12 +1093,9 @@ if ($pun_user['id'] != $id &&																	// If we aren't the user (i.e. edi
 		$user_personal[] = '<dd><span class="website"><a href="'.$user['url'].'" rel="nofollow">'.$user['url'].'</a></span></dd>';
 	}
 
-	if ($user['email_setting'] == '0' && !$pun_user['is_guest'] && $pun_user['g_send_email'] == '1')
-		$email_field = '<a href="mailto:'.pun_htmlspecialchars($user['email']).'">'.pun_htmlspecialchars($user['email']).'</a>';
-	else if ($user['email_setting'] == '1' && !$pun_user['is_guest'] && $pun_user['g_send_email'] == '1')
-		$email_field = '<a href="misc.php?email='.$id.'">'.$lang_common['Send email'].'</a>';
-	else
-		$email_field = '';
+        // link sendemail to osm.org sendmessage (modification because of special OSM login)
+        $email_field = '<a href="https://www.openstreetmap.org/message/new/' . $user['username'] . '" target="_blank">' . $lang_common['Send email'] . '</a>';
+        	
 	if ($email_field != '')
 	{
 		$user_personal[] = '<dt>'.$lang_common['Email'].'</dt>';

--- a/viewtopic.php
+++ b/viewtopic.php
@@ -275,13 +275,11 @@ while ($cur_post = $db->fetch_assoc($result))
 
 			if ($pun_config['o_show_post_count'] == '1' || $pun_user['is_admmod'])
 				$user_info[] = '<dd><span>'.$lang_topic['Posts'].' '.forum_number_format($cur_post['num_posts']).'</span></dd>';
+                        
+			// link sendemail to osm.org sendmessage (modification because of special OSM login)
+                        $email_field = '<a href="https://www.openstreetmap.org/message/new/' . $user['username'] . '" target="_blank">' . $lang_common['Email'] . '</a>';
 
-			// Now let's deal with the contact links (Email and URL)
-			if ((($cur_post['email_setting'] == '0' && !$pun_user['is_guest']) || $pun_user['is_admmod']) && $pun_user['g_send_email'] == '1')
-				$user_contacts[] = '<span class="email"><a href="mailto:'.pun_htmlspecialchars($cur_post['email']).'">'.$lang_common['Email'].'</a></span>';
-			else if ($cur_post['email_setting'] == '1' && !$pun_user['is_guest'] && $pun_user['g_send_email'] == '1')
-				$user_contacts[] = '<span class="email"><a href="misc.php?email='.$cur_post['poster_id'].'">'.$lang_common['Email'].'</a></span>';
-
+                        // Now let's deal with the contact links (URL)
 			if ($cur_post['url'] != '')
 			{
 				if ($pun_config['o_censoring'] == '1')


### PR DESCRIPTION
Because of the OSM login most of the users don't have registered an email address. But the forum internal email function suggests that it sends an email correctly even if there is no valid address. 

While there is a working OSM Message Service (osm.org), we should use that one instead of a redundant system in the forum.
