### PR TITLE
add approve info to posting places

### DIFF
--- a/include/email.php
+++ b/include/email.php
@@ -217,7 +217,7 @@ function pun_mail($to, $subject, $message, $reply_to_email = '', $reply_to_name 
 {
 	global $pun_config, $lang_common;
 
-	// Give up if there is no target address
+	// Give up if there is no target address (modification because of special OSM login)
 	if ($to == '')
 		return;
 

--- a/profile.php
+++ b/profile.php
@@ -1093,12 +1093,9 @@ if ($pun_user['id'] != $id &&																	// If we aren't the user (i.e. edi
 		$user_personal[] = '<dd><span class="website"><a href="'.$user['url'].'" rel="nofollow">'.$user['url'].'</a></span></dd>';
 	}
 
-	if ($user['email_setting'] == '0' && !$pun_user['is_guest'] && $pun_user['g_send_email'] == '1')
-		$email_field = '<a href="mailto:'.pun_htmlspecialchars($user['email']).'">'.pun_htmlspecialchars($user['email']).'</a>';
-	else if ($user['email_setting'] == '1' && !$pun_user['is_guest'] && $pun_user['g_send_email'] == '1')
-		$email_field = '<a href="misc.php?email='.$id.'">'.$lang_common['Send email'].'</a>';
-	else
-		$email_field = '';
+        // link sendemail to osm.org sendmessage (modification because of special OSM login)
+        $email_field = '<a href="https://www.openstreetmap.org/message/new/' . $user['username'] . '" target="_blank">' . $lang_common['Send email'] . '</a>';
+        	
 	if ($email_field != '')
 	{
 		$user_personal[] = '<dt>'.$lang_common['Email'].'</dt>';

--- a/viewtopic.php
+++ b/viewtopic.php
@@ -280,13 +280,11 @@ while ($cur_post = $db->fetch_assoc($result))
 
 			if ($pun_config['o_show_post_count'] == '1' || $pun_user['is_admmod'])
 				$user_info[] = '<dd><span>'.$lang_topic['Posts'].' '.forum_number_format($cur_post['num_posts']).'</span></dd>';
+                        
+			// link sendemail to osm.org sendmessage (modification because of special OSM login)
+                        $email_field = '<a href="https://www.openstreetmap.org/message/new/' . $user['username'] . '" target="_blank">' . $lang_common['Email'] . '</a>';
 
-			// Now let's deal with the contact links (Email and URL)
-			if ((($cur_post['email_setting'] == '0' && !$pun_user['is_guest']) || $pun_user['is_admmod']) && $pun_user['g_send_email'] == '1')
-				$user_contacts[] = '<span class="email"><a href="mailto:'.pun_htmlspecialchars($cur_post['email']).'">'.$lang_common['Email'].'</a></span>';
-			else if ($cur_post['email_setting'] == '1' && !$pun_user['is_guest'] && $pun_user['g_send_email'] == '1')
-				$user_contacts[] = '<span class="email"><a href="misc.php?email='.$cur_post['poster_id'].'">'.$lang_common['Email'].'</a></span>';
-
+                        // Now let's deal with the contact links (URL)
 			if ($cur_post['url'] != '')
 			{
 				if ($pun_config['o_censoring'] == '1')


### PR DESCRIPTION
New users don't get a proper information that their posts need to be approved first. It only flashes by for some seconds while the page is redirecting after the post. 

The update will put a explicit note for this users at the write areas.